### PR TITLE
Add virtual package keywords.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,6 +6,9 @@ Build-Depends: debhelper (>= 9),dh-autoreconf,autotools-dev,libopx-common-dev,li
 Standards-Version: 3.9.3
 
 Package: libopx-nas-platform-s6000-1
+Conflicts: libopx-nas-platform1
+Provides: libopx-nas-platform1
+Replaces: libopx-nas-platform1
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Network Abstraction s6000 Platform specific files and implementation


### PR DESCRIPTION
Change adds Conflicts, Provides, and Replaces kewords for virtual
package libopx-nas-platform1 provided by libopx-nas-platform-s6000-1.