### PR TITLE
Explicitly specify libraries to avoid overlinking

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,4 +10,4 @@ libopx_nas_platform_la_CXXFLAGS=-std=c++11
 
 libopx_nas_platform_la_LDFLAGS=-shared -version-info 1:1:0
 
-libopx_nas_platform_la_LIBADD= -lopx_common -lopx_cps_api_common -lopx_logging
+libopx_nas_platform_la_LIBADD=-lopx_logging

--- a/configure.ac
+++ b/configure.ac
@@ -21,21 +21,10 @@ AC_PROG_RANLIB
 LT_INIT([shared])
 
 # Checks for libraries.
-# FIXME: Replace `main' with a function in `-lopx_common':
-AC_CHECK_LIB([opx_common], [main])
-# FIXME: Replace `main' with a function in `-lopx_cps_class_map':
-AC_CHECK_LIB([opx_cps_class_map], [main])
-# FIXME: Replace `main' with a function in `-lopx_logging':
-AC_CHECK_LIB([opx_logging], [main])
-# FIXME: Replace `main' with a function in `-lopx_cps':
-AC_CHECK_LIB([opx_cps], [main])
 
 # Checks for header files.
-AC_CHECK_HEADERS([string.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
-AC_TYPE_SIZE_T
-AC_TYPE_UINT64_T
 
 # Checks for library functions.
 


### PR DESCRIPTION
Change from using AC_CHECK_LIB, which implicitly adds libraries to the
link regardless of whether they are needed, to explicitly listing libs
with *_LIBADD.